### PR TITLE
MINOR: disable fake links; enable real links; fix wording

### DIFF
--- a/docs/en/introduction-and-logging-in.md
+++ b/docs/en/introduction-and-logging-in.md
@@ -9,26 +9,25 @@ Hello, and welcome to the SilverStripe CMS web help. Hopefully, you should be ab
 
 If you have not yet installed SilverStripe, but want to follow along, you can use our interactive demo at [http://demo.silverstripe.com/](http://ss3.demo.silverstripe.org/) to give SilverStripe a try. 
 
-You can access this Help document by clicking on "Help" inside your SilverStripe installation at any time. 
+After logging into the SilverStripe CMS, you can access this Help document at any time by clicking on the "Help" button, which can be found on the left and indicated by an "i" icon. 
 
 ## Logging In
 
-To access the SilverStripe CMS, you need a username and password.  Usernames and passwords can only be given by the site's administrator.  If you don't have a username or password, contact the person or organization that created the website.  
+To access the SilverStripe CMS, you need to log in with a username and password.  Usernames and passwords can only be given by the site's administrator.  If you don't have a username or password, contact the person or organization that created the website.  
 
-Open your web browser. (It is best to use the latest version of your browser for the best experience.)  
+Open your web browser (It is best to use the latest version of your browser for the best experience).
 
-To get to the login page for the site administration, type in your website address, and add "/admin" to the end.  For example, if your website was http://www.yoursite.com/, your login page would be found at http://www.yoursite.com/admin.  
+To get to the login page for site administration using the CMS, type in your website address and add "/admin" to the end.  For example, if your website was http://<i></i>www.yoursite.com/, your login page would be found at http://<i></i>www.yoursite.com/admin.  
 
-On the login page, enter your login (usually your e-mail address) and password.  This will take you to the CMS main screen. 
 
-*Page viewable by browsing to http://www.mysite.com/admin*
+*The CMS login page at the address http://<i></i>www.yoursite.com/admin should look like the following:*
 
 ![Login to SilverStripe CMS](_images/general-login.png)
 
+On the login page above, enter your login (usually your e-mail address) and your password. This will take you to the CMS main screen. 
+
 <div class="note" markdown="1">
-If you select "Remember me next time?," the login fields will prepopulate the next time you log into the CMS. Only use this option on a computer where you alone have access.
-
-If you can't remember your password, click on "I've lost my password." You'll be asked to enter your email address and will receive an email with a link that allows you to reset your password.
-
-If you are managing other CMS users and want to reset a password for somebody else, refer to Changing and Managing Users.
+If you check the "Remember me next time?" box, the login fields will prepopulate with your username and password when logging into the CMS in the future. Only use this option on a computer where you alone have access.
+If you can't remember your password, click on "I've lost my password." link. You'll be asked to enter your email address and will subsequently be sent an email containing a link that allows you to reset your password.
+If you are managing other CMS users and want to reset a password for somebody else, refer to the [Change and manage user accounts](changing-and-managing-users) section.
 </div>


### PR DESCRIPTION
Note: in order to deactivate links on urls in Markdown, one can use &lt;i&gt;&lt;/i&gt; in the url. See https://gist.github.com/alexpeattie/4729247

Alternatively, one can use backticks which gives a light gray background color. Which is preferred ?



