### PR TITLE
Update 01_Creating_New_Pages.md

### DIFF
--- a/docs/en/02_Creating_pages_and_content/00_Pages/01_Creating_New_Pages.md
+++ b/docs/en/02_Creating_pages_and_content/00_Pages/01_Creating_New_Pages.md
@@ -37,7 +37,7 @@ There are many different page types in SilverStripe, each with their own functio
 
 Depending on the code and modules included in your site, your page type list could contain any number of other page types. This could include [blog pages](/optional_features/blogs), [user defined forms](/optional_features/forms), or news pages.
 
-The home page of the site, shown by default when a visitor browses directly to the root of your domain, is identified within  Silverstripe by the URL segment being set as 'home'.
+The home page of the site, shown by default when a visitor browses directly to the root of your domain (eg. www.example.com/), is identified within SilverStripe by the URL segment being set to 'home'.
 
 ### Changing an existing page type
 

--- a/docs/en/02_Creating_pages_and_content/00_Pages/01_Creating_New_Pages.md
+++ b/docs/en/02_Creating_pages_and_content/00_Pages/01_Creating_New_Pages.md
@@ -29,7 +29,6 @@ There are many different page types in SilverStripe, each with their own functio
 #### Basic pages
 
 * **Page**—The most generic content page type. Page contains HTML content, and has no customised functionality. Most pages you create on your site will be of this type.
-* **Home Page**—The Home Page behaves like any other page, with the exception that it is the home page for your site. Users will see this page first if they browse directly to the root of your domain.
 * **Error Page**—This page will display an error when produced by the website. Error pages can be created for individual error types, such as, a 404 "Page not found" can look different from a 403 "Forbidden" page.
 * **Redirector Page**—This page type redirects the user to either an internal page on your website, or a page on an external website.
 * **Virtual Page**—A virtual page displays the content of an existing page on your website. This is different from a redirector page, as a redirector essentially links one location on the website to another, while a virtual page copies the content of another page. Editing the virtual page will, in turn, edit the copied virtual page.
@@ -37,6 +36,8 @@ There are many different page types in SilverStripe, each with their own functio
 #### Other types of pages
 
 Depending on the code and modules included in your site, your page type list could contain any number of other page types. This could include [blog pages](/optional_features/blogs), [user defined forms](/optional_features/forms), or news pages.
+
+The home page of the site, shown by default when a visitor browses directly to the root of your domain, is identified within  Silverstripe by the URL segment being set as 'home'.
 
 ### Changing an existing page type
 


### PR DESCRIPTION
Remove reference to 'Home Page' page type.

In a default SS4 installation, there is no 'Home Page' type, so this may be confusing for users if they can't select it in the list.

I've added an extra note to try and explain how the home page is determined, in case a user wonders