### PR TITLE
Add symlink for Document Converter

### DIFF
--- a/docs/en/03_Optional_features/17_Document_Converter
+++ b/docs/en/03_Optional_features/17_Document_Converter
@@ -1,0 +1,1 @@
+../../../../silverstripe-documentconverter_master/docs/en/userguide/


### PR DESCRIPTION
Relies on https://github.com/silverstripe/userhelp.silverstripe.org/pull/68
Original issue: https://github.com/silverstripe/silverstripe-userhelp-content/issues/122