### PR TITLE
DOCS Update symlinks to be consistent with repos in userhelp.silverstripe.org

### DIFF
--- a/docs/en/03_Optional_features/15_Modules_report
+++ b/docs/en/03_Optional_features/15_Modules_report
@@ -1,1 +1,1 @@
-../../../../silverstripe-maintenance_1/docs/en/userguide/
+../../../../maintenance_1/docs/en/userguide/

--- a/docs/en/03_Optional_features/16_Share_draft_content
+++ b/docs/en/03_Optional_features/16_Share_draft_content
@@ -1,1 +1,1 @@
-../../../../silverstripe-sharedraftcontent_master/docs/en/userguide/
+../../../../sharedraftcontent_master/docs/en/userguide/

--- a/docs/en/03_Optional_features/17_Document_Converter
+++ b/docs/en/03_Optional_features/17_Document_Converter
@@ -1,1 +1,1 @@
-../../../../silverstripe-documentconverter_master/docs/en/userguide/
+../../../../documentconverter_master/docs/en/userguide/


### PR DESCRIPTION
Relies on: https://github.com/silverstripe/userhelp.silverstripe.org/pull/72