### PR TITLE
DOC Update userhelp references from CMS4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Silverstripe User Help
 
-The **Silverstripe 4.0** User Help in Markdown format, as published on
+The **Silverstripe CMS** User Help in Markdown format, as published on
 [userhelp.silverstripe.org](http://userhelp.silverstripe.org)
 ([source](https://github.com/silverstripe/doc.silverstripe.org)).
 

--- a/docs/en/01_Managing_your_website/00_Overview.md
+++ b/docs/en/01_Managing_your_website/00_Overview.md
@@ -7,7 +7,7 @@ summary: Introducing the Silverstripe CMS administration interface.
 
 The latest Silverstripe CMS administration panel is arranged in four main areas, as shown below:
 
-![Silverstripe CMS 4 overview](../_images/basic-overview.png)
+![Silverstripe CMS overview](../_images/basic-overview.png)
 
 ## CMS menu
 

--- a/docs/en/01_Managing_your_website/01_Logging_In.md
+++ b/docs/en/01_Managing_your_website/01_Logging_In.md
@@ -32,7 +32,7 @@ Only use this option on a computer where you alone have access.
 
 Additional information:
 
-* When checking this option you will stay signed in for 30 days by default. The default is 90 days on sites running less than version 4.8 of Silverstripe CMS.
+* When checking this option you will stay signed in for 30 days by default.
 * You can stay signed in on multiple devices by default.
 * Logging out of one device will clear automatic sign-ins on all of your devices by default, which means you will need to log in again next time.
 * These features may behave differently based on how the developers / administrators have configured them.

--- a/docs/en/01_Managing_your_website/04_Session_Manager.md
+++ b/docs/en/01_Managing_your_website/04_Session_Manager.md
@@ -12,7 +12,7 @@ The session manager module allows members to manage (see active and revoke) logi
 
 ## Getting started
 
-[Silverstripe CMS Session Manager](https://addons.silverstripe.org/add-ons/silverstripe/session-manager) is installed by default for users of Recipe CMS 4.9 or later.
+[Silverstripe CMS Session Manager](https://addons.silverstripe.org/add-ons/silverstripe/session-manager) is installed by default.
 
 ## Logging in
 

--- a/docs/en/01_Managing_your_website/99_How_to_find_CMS_version.md
+++ b/docs/en/01_Managing_your_website/99_How_to_find_CMS_version.md
@@ -5,7 +5,7 @@ summary: How to find out the version of Silverstripe CMS you are using.
 
 # Finding out your version of Silverstripe CMS
 
-The CMS version can be found in the help menu (Silverstripe CMS logo) at the bottom of the CMS menu. You can view the CMS version number, with full version details showing on hover. This functionality is new as of Silverstripe CMS 4, in earlier versions hover over the Silverstripe logo at the top of the CMS menu to access CMS version details.
+The CMS version can be found in the help menu (Silverstripe CMS logo) at the bottom of the CMS menu. You can view the CMS version number, with full version details showing on hover.
 
 Knowing the Silverstripe CMS version is helpful to ensure you use the correct User Help guides, to ensure compatibility of modules, and see what features are part of certain releases.
 

--- a/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/09_File_Permissions.md
+++ b/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/09_File_Permissions.md
@@ -5,10 +5,6 @@ summary: Securing files in Silverstripe CMS
 
 ## File permissions
 
-[note]
-This functionality is specifically included in Silverstripe core functionality 4.6 and above.
-[/note]
-
 Typically files and folders in Silverstripe CMS do not have any view access permissions applied to them.
 This means that when a file is published the files can be linked to, or shared on your site by anyone.
 To help reduce the risk of privacy breaches of sensitive files, particularly user submitted data, Silverstripe CMS has some helpful defaults to

--- a/docs/en/02_Creating_pages_and_content/02_Web_Content_Best_Practices.md
+++ b/docs/en/02_Creating_pages_and_content/02_Web_Content_Best_Practices.md
@@ -64,8 +64,6 @@ Meta tags also make your web page more findable. The **Meta Description** field 
 ![Meta titles](../_images/meta-title.png)
 
 [note]
-The meta fields for title and keywords have been removed in v3.1. Keywords have been removed due to an official Google press release which confirmed that [Google doesn't use the keywords tag anymore](http://googlewebmastercentral.blogspot.co.nz/2009/09/google-does-not-use-keywords-meta-tag.html).
-
 It is best to avoid repetition of keywords and phrases in the description. Google sees this as 'keyword stuffing', which is looked at as search engine spam.
 [/note]
 

--- a/docs/en/02_Creating_pages_and_content/04_Campaigns.md
+++ b/docs/en/02_Creating_pages_and_content/04_Campaigns.md
@@ -5,10 +5,6 @@ summary: Create and group new content together to be released all at once.
 
 # Campaigns overview
 
-[note]
-The Campaigns section of the CMS is new as of Silverstripe CMS 4 and therefore will continue to develop with functionality.
-[/note]
-
 Campaigns allow for a set of content types (like images and pages) on your site to be viewed and published as a collection. Items in a campaign could contain varying types of content including pages, files, data, content blocks, and forms. By default most content types can be added to a campaign but this will depend on how your data structures have been defined.
 
 Campaigns enable:

--- a/docs/en/02_Creating_pages_and_content/05_Archive.md
+++ b/docs/en/02_Creating_pages_and_content/05_Archive.md
@@ -5,10 +5,6 @@ summary: Removing content from your website and restoring it.
 
 # Archive
 
-[note]
-The Archive section of the CMS is new as of Silverstripe CMS 4 and therefore will continue to develop with functionality.
-[/note]
-
 All content which can be archived is stored within the CMS Archive. By default this includes pages, files (if activated), and content blocks. Depending on the way your CMS has been configured the Archive might extend to contain additional content types.
 
 When archiving an item, the CMS will first automatically unpublish the item if published, before sending it to the archive. The Archive stores the item along with its entire history so that it can be restored at a later date. If an item is restored then it will be returned to the relevant section of the CMS it came from in a draft state.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -5,7 +5,7 @@ title: CMS User Help
 # Silverstripe CMS User Help guide
 
 This site is a user-focused reference targeted at editors and administrators who create and manage content on Silverstripe CMS websites.
-This guide applies to version 4.x of the CMS (all releases in the Silverstripe CMS 4 release line).
+This guide applies to version 5.x of the CMS (all releases in the Silverstripe CMS 5 release line).
 
 This User Help guide also covers a number of [modules](https://addons.silverstripe.org)
 which may or may not be installed for your site. Refer to the intro for each chapter to find out the prerequisites for using a feature.


### PR DESCRIPTION
Remove references to CMS3, remove references to CMS 4 that are not relevant, and update references from 4 to 5 where appropriate.

## Parent issue
- https://github.com/silverstripe/developer-docs/issues/44