### PR TITLE
MNT Fix github action for deploying userdocs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,16 @@
-name: Build Docs
+name: Deploy Docs
 on:
+  workflow_dispatch:
   push:
     branches:
       - '3'
       - '4'
+      - '5'
     paths:
       - 'docs/**'
 jobs:
-  build:
-    name: build-docs
+  deploy:
+    name: deploy-docs
     runs-on: ubuntu-latest
     steps:
       - name: Run build hook


### PR DESCRIPTION
- Set the branches that activate the action to match the ones used by userhelp according to [the userhelp sources json](https://github.com/silverstripe/doc.silverstripe.org/blob/master/sources-user.js)
- More clearly and accurately identify the specific action (main.yml is hardly specific) in case future actions are also added.
- Add `workflow_dispatch` so that we can deploy manually (e.g. in the event a deployment fails in the future)

## Parent issue
- https://github.com/silverstripe/doc.silverstripe.org/issues/246