### PR TITLE
DOC Update syntax for callout blocks

### DIFF
--- a/docs/en/01_Managing_your_website/00_Overview.md
+++ b/docs/en/01_Managing_your_website/00_Overview.md
@@ -77,9 +77,8 @@ The Navigation toolbar area shows various data relating to individual pages such
 
 The Action toolbar at the bottom of the page allows you to save, publish (make publicly available), unpublish (return to draft), unpublish and archive (remove from site tree) or add to a campaign.
 
-[note]
-Depending on your CMS setup you may see further functionality provided by modules in the Action toolbar.
-[/note]
+> [!NOTE]
+> Depending on your CMS setup you may see further functionality provided by modules in the Action toolbar.
 
 ![SS4 publishing options](../_images/publishing-options.png)
 

--- a/docs/en/01_Managing_your_website/02_Changing_And_Managing_Users.md
+++ b/docs/en/01_Managing_your_website/02_Changing_And_Managing_Users.md
@@ -24,17 +24,15 @@ Navigate to the tab ***Users*** and click the button ***Add Member***.
 
 In the **New Member** section, you can edit the user's details. The two most important parts of the user's details are the email (which is also used for logging in) and password.
 
-[note]
-By default, an email address can only be used once in the system. It is not possible for multiple users to share the same email address.
-[/note]
+> [!NOTE]
+> By default, an email address can only be used once in the system. It is not possible for multiple users to share the same email address.
 
 ![User details](../_images/user-details.png)
 
-[note]
-Users can be in multiple groups. If you delete a user from a group, they are only removed from that group, not from the system. To fully delete a user from the system, you need to be in the root of Security.
-
-Click the link ***Security*** in the breadcrumbs or click the button ***Back*** which is shown as a left arrow icon.
-[/note]
+> [!NOTE]
+> Users can be in multiple groups. If you delete a user from a group, they are only removed from that group, not from the system. To fully delete a user from the system, you need to be in the root of Security.
+>
+> Click the link ***Security*** in the breadcrumbs or click the button ***Back*** which is shown as a left arrow icon.
 
 ## Changing a user's password
 

--- a/docs/en/01_Managing_your_website/02_Managing_Roles_And_Permissions.md
+++ b/docs/en/01_Managing_your_website/02_Managing_Roles_And_Permissions.md
@@ -30,9 +30,8 @@ Security groups are collections of users, and whatever permissions they have app
 
 One of the ways that the two can be used together is to assign similar roles to different groups. You only need to define an "editor" role once, but by applying the "editor" role to different groups with different access to different pages, so if you assigned the "editor" role to both the marketing team and development team security groups, the marketing team would be able to edit the marketing pages, and the development team would be able to edit the development pages, but they would not be able to edit each other's pages.
 
-[note]
-Groups represent a group of members, and you can assign a Group with a set of roles which are descriptors for various permissions in the system e.g. a group which has the "Administrator" role, allows access to the CMS.
-[/note]
+> [!NOTE]
+> Groups represent a group of members, and you can assign a Group with a set of roles which are descriptors for various permissions in the system e.g. a group which has the "Administrator" role, allows access to the CMS.
 
 ## Using roles
 
@@ -57,9 +56,8 @@ To navigate back to the Roles section either click the link ***Security*** in th
 
 ![Creating roles](../_images/creating-roles.png)
 
-[note]
-A role can have any number of permissions. For example, an author typically has "Access to Site Content," (they can access the "Site Content" section in the CMS; the part where all content is managed), "Access to Files & Images," (they can browse the "Files and Images" section in the CMS, organise assets in folders, upload new assets, etc.), and "Change site structure," (they can change the location for a page in the site tree and  manage the site structure and navigation).
-[/note]
+> [!NOTE]
+> A role can have any number of permissions. For example, an author typically has "Access to Site Content," (they can access the "Site Content" section in the CMS; the part where all content is managed), "Access to Files & Images," (they can browse the "Files and Images" section in the CMS, organise assets in folders, upload new assets, etc.), and "Change site structure," (they can change the location for a page in the site tree and  manage the site structure and navigation).
 
 ## Editing roles
 
@@ -80,9 +78,8 @@ Unlike roles, there are no basic groups that typically apply to all sites. Inste
 3. In the ***Members*** tab add the group name in the **Group Name** field.
 4. Click the button ***Create***.
 
-[note]
-We recommend you set up a top-level group for your entire site, as well as for each section that is managed by specific people.
-[/note]
+> [!NOTE]
+> We recommend you set up a top-level group for your entire site, as well as for each section that is managed by specific people.
 
 You can nest groups, and create sub-groups which may represent different roles. The parent group acts as a place to organise different subgroups. In this case, it's probably best not to add members directly to the parent group.
 
@@ -96,18 +93,16 @@ You can nest groups, and create sub-groups which may represent different roles. 
 
 If you wish to add a new member instead of choosing from an already established member, click the button ***Add Member***.
 
-[note]
-Users can be in multiple groups. If you delete a user from a group, they are only removed from that group, not from the system. To fully delete a user, you need to be in the root of Security. To reach the security group root click the link ***Security*** or the ***Back*** button which is shown as a left arrow in the Navigation toolbar.
-[/note]
+> [!NOTE]
+> Users can be in multiple groups. If you delete a user from a group, they are only removed from that group, not from the system. To fully delete a user, you need to be in the root of Security. To reach the security group root click the link ***Security*** or the ***Back*** button which is shown as a left arrow in the Navigation toolbar.
 
 ## Editing and deleting groups
 
 1. To edit a group, click the Group Name list item. This opens the group details. You can change the Group name, and add, edit or delete members.
 2. To delete a group, click the ***Delete*** button shown as a trash icon.
 
-[note]
-Note that a single user can belong to more than one group and that deleting a group does not delete its members.
-[/note]
+> [!NOTE]
+> Note that a single user can belong to more than one group and that deleting a group does not delete its members.
 
 ## Assigning roles to security group members
 

--- a/docs/en/01_Managing_your_website/03_Changing_Your_Password.md
+++ b/docs/en/01_Managing_your_website/03_Changing_Your_Password.md
@@ -11,6 +11,5 @@ summary: Guidance on how to change the password of your Silverstripe CMS account
 4. Enter your current, new and confirmed password.
 5. Click the button ***Save***.
 
-[note]
-You can also update your e-mail address and name.
-[/note]
+> [!NOTE]
+> You can also update your e-mail address and name.

--- a/docs/en/01_Managing_your_website/04_Session_Manager.md
+++ b/docs/en/01_Managing_your_website/04_Session_Manager.md
@@ -17,9 +17,8 @@ The session manager module allows members to manage (see active and revoke) logi
 
 When logging in with *_Keep me signed in for 30 days_*" checked, a session will remain active on that device for the full 30 days unless it is terminated prior to that allocated timeframe. Without this option checked, a session will only last for the duration of your browser session.
 
-[notice]
-You should not use the "Keep me signed in" functionality when working on a device shared with other users (e.g.: internet café computer or a public library workstation).
-[/notice]
+> [!WARNING]
+> You should not use the "Keep me signed in" functionality when working on a device shared with other users (e.g.: internet café computer or a public library workstation).
 
 ![Silverstripe CMS log in form](../_images/session-manager-logging-in.png)
 
@@ -37,9 +36,8 @@ There is various data associated with every login session that can be used to id
 * Last active time
 * Sign-in time
 
-[notice]
-A member can only view login sessions for their own profile. No one else will have access to view your sessions.
-[/notice]
+> [!WARNING]
+> A member can only view login sessions for their own profile. No one else will have access to view your sessions.
 
 ## Revoking access
 
@@ -47,6 +45,5 @@ To remove access for a session associated with a device, click the **Log out** l
 
 Administrators can also revoke _all_ active sessions for _all_ users by triggering the `dev/tasks/InvalidateAllSessions` task either in the browser or via the CLI. Note that this will also revoke the session of the user activating the task, so if this is triggered via the browser, that user will need to log back in to perform further actions.
 
-[notice]
-With exception to the invalidate all sessions task, a member can only revoke access for their _own_ profile. No one else will have access to remove your sessions.
-[/notice]
+> [!WARNING]
+> With exception to the invalidate all sessions task, a member can only revoke access for their _own_ profile. No one else will have access to remove your sessions.

--- a/docs/en/02_Creating_pages_and_content/00_Pages/01_Creating_New_Pages.md
+++ b/docs/en/02_Creating_pages_and_content/00_Pages/01_Creating_New_Pages.md
@@ -18,9 +18,8 @@ For example, if you'd like to create a new page in the "About Us" section of you
 
 ![Adding a page](../../_images/adding-a-page.png)
 
-[note]
- Different page types will usually have different content fields to fill in, and may also have a slightly different layout when the page is viewed. Depending on the functionality of your site, you may also be able to create "News Article" page types etc.
-[/note]
+> [!NOTE]
+> Different page types will usually have different content fields to fill in, and may also have a slightly different layout when the page is viewed. Depending on the functionality of your site, you may also be able to create "News Article" page types etc.
 
 Don't worry if you create your page in the wrong location. Pages can be moved and re-ordered easily, see [Reordering Pages](reordering_pages/) to learn more.
 

--- a/docs/en/02_Creating_pages_and_content/00_Pages/05_Rolling_Back_Pages.md
+++ b/docs/en/02_Creating_pages_and_content/00_Pages/05_Rolling_Back_Pages.md
@@ -17,9 +17,8 @@ You can preview how the current snapshot looked on the site, by switching to **P
 3. Click the button ***Revert to this version***, once you have located the snapshot that you want to roll back to.
 4. The page will be rolled back to this version. Click the button ***Publish*** to make it live.
 
-[note]
-When a page is rolled back to the previous version, it is only rolled back in the backend CMS as a draft. To show the rolled back page on the public-facing website, it needs to be published.
-[/note]
+> [!NOTE]
+> When a page is rolled back to the previous version, it is only rolled back in the backend CMS as a draft. To show the rolled back page on the public-facing website, it needs to be published.
 
 ## Comparing Snapshots
 

--- a/docs/en/02_Creating_pages_and_content/00_Pages/07_Hiding_A_Page.md
+++ b/docs/en/02_Creating_pages_and_content/00_Pages/07_Hiding_A_Page.md
@@ -15,14 +15,12 @@ introduction: You can hide a page so it will not appear in the website navigatio
 If you are changing the search visibility on an existing page, it may take a few weeks for the page to disappear from search engine results.
 5. Click the button ***Publish***.
 
-[note]
-You can see which pages are hidden by the page names colored grey in the site tree.
-[/note]
+> [!NOTE]
+> You can see which pages are hidden by the page names colored grey in the site tree.
 
 Only people who have access to the full page URL will be able to find the page. However, you can still link to the page from other pages, see [Inserting links](../creating_and_editing_content/inserting_links) to learn more.
 
 ![Page visibility](../../_images/Hiding-Pages.png)
 
-[note]
-You can either choose to hide the page from the menus or from search engines, you do not need to do both.
-[/note]
+> [!NOTE]
+> You can either choose to hide the page from the menus or from search engines, you do not need to do both.

--- a/docs/en/02_Creating_pages_and_content/00_Pages/08_Batch_Actions.md
+++ b/docs/en/02_Creating_pages_and_content/00_Pages/08_Batch_Actions.md
@@ -13,9 +13,8 @@ summary: Performing actions on multiple pages at once.
 2. Select the action **Publish** to perform from the dropdown field.
 3. Select any number of pages you want to publish, and click the button ***Go*** to perform the selected action.
 
-[note]
-Available pages for the selected action will have checkbox fields beside them.
-[/note]
+> [!NOTE]
+> Available pages for the selected action will have checkbox fields beside them.
 
 ### Archiving multiple pages
 

--- a/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/01_Editing_Content.md
+++ b/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/01_Editing_Content.md
@@ -20,9 +20,8 @@ If your website includes other features specific to all pages you may see other 
 
 ![Editing page fields](../../_images/Page-Fields.png)
 
-[note]
-Every time you click the button ***Save*** or ***Publish*** a snapshot of the page is saved in history, which you can then revert to at any time, see [Rolling Back Pages](../pages/rolling_back_pages) to learn more.
-[/note]
+> [!NOTE]
+> Every time you click the button ***Save*** or ***Publish*** a snapshot of the page is saved in history, which you can then revert to at any time, see [Rolling Back Pages](../pages/rolling_back_pages) to learn more.
 
 ## Formatting content
 

--- a/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/02_Previewing_Changes.md
+++ b/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/02_Previewing_Changes.md
@@ -6,9 +6,8 @@ introduction: If you've made some substantial changes to a page, and want to che
 
 # Previewing changes
 
-[note]
-Remember when editing content to save your page regularly.
-[/note]
+> [!NOTE]
+> Remember when editing content to save your page regularly.
 
 Click the button ***Save*** in the publishing bar.
 
@@ -21,11 +20,10 @@ You can either:
 
 ![Preview mode site draft](../../_images/preview-draft-published.png)
 
-[note]
-Some data doesn't have draft and published states. When editing data like that you might instead see the simple ***Preview*** state.
-
-![Preview mode no draft or published states](../../_images/preview-unversioned.png)
-[/note]
+> [!NOTE]
+> Some data doesn't have draft and published states. When editing data like that you might instead see the simple ***Preview*** state.
+>
+> ![Preview mode no draft or published states](../../_images/preview-unversioned.png)
 
 ## Previewing your changes
 

--- a/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/04_Images_And_Documents.md
+++ b/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/04_Images_And_Documents.md
@@ -13,10 +13,9 @@ Files can be displayed or linked to from multiple places. This means that by upd
 
 You can either upload files within the Files section or directly from pages through the HTML editor. The Files section supports a range of different file types which are typical for use on the web including images, videos, and documents. See [Web content best practices](/creating_pages_and_content/web_content_best_practices/) for additional tips on how to prepare files for use on the web.
 
-[note]
-By default, uploaded files are placed in the "Uploads" directory.
-If you place an image in a page, and later move or rename that image the CMS will automatically keep track of those changes, so your webpage will remain unchanged—you don't even have to republish the page.
-[/note]
+> [!NOTE]
+> By default, uploaded files are placed in the "Uploads" directory.
+> If you place an image in a page, and later move or rename that image the CMS will automatically keep track of those changes, so your webpage will remain unchanged—you don't even have to republish the page.
 
 ## Uploading images
 
@@ -34,15 +33,13 @@ You should now see the files you uploaded within your chosen folder.
 
 ![Uploaded files](../../_images/files-uploaded.png)
 
-[note]
-This same process can be used for filetypes other than images, see [Linking Documents](linking_documents/) to learn more.
-[/note]
+> [!NOTE]
+> This same process can be used for filetypes other than images, see [Linking Documents](linking_documents/) to learn more.
 
 ## Uploading images from a page
 
-[note]
-Pages that contain a HTML editor allow you to place files into the content area, some pages don't have a HTML editor area by default and might require a different [Page type](/creating_pages_and_content/pages/creating_new_pages/) or for a Content Block to be added.
-[/note]
+> [!NOTE]
+> Pages that contain a HTML editor allow you to place files into the content area, some pages don't have a HTML editor area by default and might require a different [Page type](/creating_pages_and_content/pages/creating_new_pages/) or for a Content Block to be added.
 
 1. Navigate to your page within the **Pages** section.
 2. In the HTML editor click on the button ***Insert from Files*** which is shown as an image icon.  

--- a/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/05_Inserting_Links.md
+++ b/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/05_Inserting_Links.md
@@ -7,9 +7,8 @@ summary: Linking to internal and external content using hyperlinks.
 
 ## Inserting links
 
-[note]
-Instead of "Click here" or "Click here to read more about widgets" as the link text, it would be better to say "Read more about widgets". You can also add additional information in the link description field (available to screen readers), although it's best practice that the description is different from the link text and provides additional clarification (otherwise screen readers will read the text twice).
-[/note]
+> [!NOTE]
+> Instead of "Click here" or "Click here to read more about widgets" as the link text, it would be better to say "Read more about widgets". You can also add additional information in the link description field (available to screen readers), although it's best practice that the description is different from the link text and provides additional clarification (otherwise screen readers will read the text twice).
 
 1. You can either type out the link text in the HTML editor or select where you want the link to be added and enter the **Link text** later.
 2. Click and drag across the text that you'd like to add a link to, to highlight it.
@@ -22,9 +21,8 @@ Instead of "Click here" or "Click here to read more about widgets" as the link t
 2. Select a page from the **Select a page** dropdown field.
 3. Select a page to link and click the button ***Insert link***.
 
-[note]
-There are different processes for internal and external links. When pages are moved or deleted, the links on other pages of the site will be automatically changed to the new pages location. This allows you to move pages around without worrying about breaking the site's structure or checking the site for broken links.
-[/note]
+> [!NOTE]
+> There are different processes for internal and external links. When pages are moved or deleted, the links on other pages of the site will be automatically changed to the new pages location. This allows you to move pages around without worrying about breaking the site's structure or checking the site for broken links.
 
 ### Anchor on a page
 
@@ -56,6 +54,5 @@ Enter the following link specifications:
 * Select a file from the CMS.
 2. Click the button ***Insert link***.
 
-[note]
-You can also add hyperlinks to documents that you have uploaded to your website, such as a PDF file, DOC file, audio file, video file, or any sort of file that is not a webpage. See [Images and documents](images_and_documents) to learn more.
-[/note]
+> [!NOTE]
+> You can also add hyperlinks to documents that you have uploaded to your website, such as a PDF file, DOC file, audio file, video file, or any sort of file that is not a webpage. See [Images and documents](images_and_documents) to learn more.

--- a/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/06_Inserting_Images.md
+++ b/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/06_Inserting_Images.md
@@ -14,9 +14,8 @@ summary: Inserting and resizing images in your content.
 4. Locate the image(s) you'd like to insert, and click the button ***Open***.
 5. Once the image(s) have uploaded, click the button ***Insert file***. You can select the image in the HTML editor and drag the drag handles to resize to your required size.
 
-[note]
-Image files for a website must be in either JPG, GIF, PNG or WebP format. If your image currently exists in a Word or Publisher file, you must first save the image as one of these file types.
-[/note]
+> [!NOTE]
+> Image files for a website must be in either JPG, GIF, PNG or WebP format. If your image currently exists in a Word or Publisher file, you must first save the image as one of these file types.
 
 ## Setting the alignment of an image
 

--- a/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/07_Inserting_Media.md
+++ b/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/07_Inserting_Media.md
@@ -9,9 +9,8 @@ To add media such as a video into a page, you should first upload it to a video 
 
 YouTube allows you to mark a video as **Unlisted** so that it will not appear on YouTube.com search results etc. Also adverts will not be displayed on your video unless you enable that option from within YouTube.
 
-[note]
-This feature isn't just limited to video, you can also embed Flickr slideshows and other embeddable widgets this way, if they support the 'oEmbed' standard.
-[/note]
+> [!NOTE]
+> This feature isn't just limited to video, you can also embed Flickr slideshows and other embeddable widgets this way, if they support the 'oEmbed' standard.
 
 You can upload your video to one of the supported media services (many of the [services that support oEmbed](http://oembed.com/#section7) protocol can be handled in this way):
 * YouTube
@@ -43,6 +42,5 @@ Metadata such as the media title or dimensions from the media service may be cac
 
 If you change the source media in some way (for example, changing the title), you may need to clear the cached metadata to see this change reflected on your website. You can do this by re-saving or publishing a page containing the embedded media. This will correct any pages containing that media.
 
-[note]
-To edit the embedded media further, select the media in the HTML editor and click the button ***Insert media from URL***.
-[/note]
+> [!NOTE]
+> To edit the embedded media further, select the media in the HTML editor and click the button ***Insert media from URL***.

--- a/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/08_Linking_Documents.md
+++ b/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/08_Linking_Documents.md
@@ -7,9 +7,8 @@ summary: Uploading and linking documents from the Silverstripe CMS.
 
 To upload documents, such as PDF files, Word .DOC documents, and downloadable audio and video files, navigate to the **Files** area in the CMS menu.
 
-[note]
-Be sure to ***Save*** any page you are working on in the editing page to a Draft before doing so, otherwise you may lose any changes you have made since the last save.
-[/note]
+> [!NOTE]
+> Be sure to ***Save*** any page you are working on in the editing page to a Draft before doing so, otherwise you may lose any changes you have made since the last save.
 
 Click the button ***Upload***, see [Uploading images from Files](images_and_documents) to learn more.
 
@@ -28,6 +27,5 @@ Click the button ***Upload***, see [Uploading images from Files](images_and_docu
 
 ![Link file modal](../../_images/link-file-modal.png)
 
-[note]
-Click the link from the HTML editor to further edit or remove the link.
-[/note]
+> [!NOTE]
+> Click the link from the HTML editor to further edit or remove the link.

--- a/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/09_File_Permissions.md
+++ b/docs/en/02_Creating_pages_and_content/01_Creating_And_Editing_Content/09_File_Permissions.md
@@ -5,9 +5,8 @@ summary: Securing files in Silverstripe CMS
 
 ## File permissions
 
-[note]
-This functionality is specifically included in Silverstripe core functionality 4.6 and above.
-[/note]
+> [!NOTE]
+> This functionality is specifically included in Silverstripe core functionality 4.6 and above.
 
 Typically files and folders in Silverstripe CMS do not have any view access permissions applied to them.
 This means that when a file is published the files can be linked to, or shared on your site by anyone.
@@ -65,7 +64,6 @@ Examples of where these icons can be found in Silverstripe CMS:
 
 ![Overview of icons usage on thumbnails and headers in the Files area](../../_images/overview-icons.png)
 
-[note]
-Folder with restricted access containing files with custom permissions and their associated file icons.
-FS - Form submission
-[/note]
+> [!NOTE]
+> Folder with restricted access containing files with custom permissions and their associated file icons.
+> FS - Form submission

--- a/docs/en/02_Creating_pages_and_content/02_Web_Content_Best_Practices.md
+++ b/docs/en/02_Creating_pages_and_content/02_Web_Content_Best_Practices.md
@@ -45,17 +45,16 @@ When you first create a new page, start by entering its name in the **Page name*
 * **URL Segment**—generated based on the page name, using the words and dashes. Human-readable URLs make a page more easily found by search engines. Well-written URLs can also serve as their own anchor text when copied and pasted as links in forums, blogs, social media networks, or other online venues. Most of the time, the URL that Silverstripe CMS generates will be fine, but you can manually change it if necessary.
 * **Navigation label**—appears in your site's navigation. Sometimes when you have a lengthy page name, it makes sense to create a shortened navigation label.
 
-[note]
-Your website developer will have configured your Silverstripe CMS website for either simple or hierarchical URLs.
-
-Simple URLs only use a single level of depth. For example, a page for a staff member might be called "John Smith", and its URL would be www.example.com/john-smith. Simple URLs are short and memorable, however, you are more likely to have multiple pages with the same name.
-
-If a URL is already in use, the CMS will generate URLs with numbers, e.g., /staff-members-1, /staff-members-2, etc.
-
-In this case, it's a good idea to manually change the URLs to something more meaningful, such as /staff-members-berlin, /staff-members-hong-kong.
-
-Hierarchical URLs provide a logical path for a page as it exists in the site's structure. In our example, this might be www.example.com/offices/new-york/staff/john-smith
-[/note]
+> [!NOTE]
+> Your website developer will have configured your Silverstripe CMS website for either simple or hierarchical URLs.
+>
+> Simple URLs only use a single level of depth. For example, a page for a staff member might be called "John Smith", and its URL would be www.example.com/john-smith. Simple URLs are short and memorable, however, you are more likely to have multiple pages with the same name.
+>
+> If a URL is already in use, the CMS will generate URLs with numbers, e.g., /staff-members-1, /staff-members-2, etc.
+>
+> In this case, it's a good idea to manually change the URLs to something more meaningful, such as /staff-members-berlin, /staff-members-hong-kong.
+>
+> Hierarchical URLs provide a logical path for a page as it exists in the site's structure. In our example, this might be www.example.com/offices/new-york/staff/john-smith
 
 ### Meta tags
 
@@ -63,11 +62,10 @@ Meta tags also make your web page more findable. The **Meta Description** field 
 
 ![Meta titles](../_images/meta-title.png)
 
-[note]
-The meta fields for title and keywords have been removed in v3.1. Keywords have been removed due to an official Google press release which confirmed that [Google doesn't use the keywords tag anymore](http://googlewebmastercentral.blogspot.co.nz/2009/09/google-does-not-use-keywords-meta-tag.html).
-
-It is best to avoid repetition of keywords and phrases in the description. Google sees this as 'keyword stuffing', which is looked at as search engine spam.
-[/note]
+> [!NOTE]
+> The meta fields for title and keywords have been removed in v3.1. Keywords have been removed due to an official Google press release which confirmed that [Google doesn't use the keywords tag anymore](http://googlewebmastercentral.blogspot.co.nz/2009/09/google-does-not-use-keywords-meta-tag.html).
+>
+> It is best to avoid repetition of keywords and phrases in the description. Google sees this as 'keyword stuffing', which is looked at as search engine spam.
 
 ### Clean HTML
 

--- a/docs/en/02_Creating_pages_and_content/04_Campaigns.md
+++ b/docs/en/02_Creating_pages_and_content/04_Campaigns.md
@@ -5,9 +5,8 @@ summary: Create and group new content together to be released all at once.
 
 # Campaigns overview
 
-[note]
-The Campaigns section of the CMS is new as of Silverstripe CMS 4 and therefore will continue to develop with functionality.
-[/note]
+> [!NOTE]
+> The Campaigns section of the CMS is new as of Silverstripe CMS 4 and therefore will continue to develop with functionality.
 
 Campaigns allow for a set of content types (like images and pages) on your site to be viewed and published as a collection. Items in a campaign could contain varying types of content including pages, files, data, content blocks, and forms. By default most content types can be added to a campaign but this will depend on how your data structures have been defined.
 

--- a/docs/en/02_Creating_pages_and_content/05_Archive.md
+++ b/docs/en/02_Creating_pages_and_content/05_Archive.md
@@ -5,9 +5,8 @@ summary: Removing content from your website and restoring it.
 
 # Archive
 
-[note]
-The Archive section of the CMS is new as of Silverstripe CMS 4 and therefore will continue to develop with functionality.
-[/note]
+> [!NOTE]
+> The Archive section of the CMS is new as of Silverstripe CMS 4 and therefore will continue to develop with functionality.
 
 All content which can be archived is stored within the CMS Archive. By default this includes pages, files (if activated), and content blocks. Depending on the way your CMS has been configured the Archive might extend to contain additional content types.
 
@@ -27,9 +26,8 @@ Location of the **Archive** action for pages:
 
 Location of the **Archive** action for files:
 
-[note]
-Archiving for files is turned off by default.
-[/note]
+> [!NOTE]
+> Archiving for files is turned off by default.
 
 ![Archiving in the files section](../_images/archive-file.png)
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -16,9 +16,8 @@ Check out our [community](https://www.silverstripe.org/community/) overview for 
 
 For customers of Silverstripe Ltd., the company behind the CMS, visit [silverstripe.com](https://www.silverstripe.com/).
 
-[note]
-Sections of User Help are still a work in progress. If you would like to help contribute to the Silverstripe CMS User Help guide you can edit the pages on [GitHub](https://github.com/silverstripe/silverstripe-userhelp-content/) or create an [issue](https://github.com/silverstripe/silverstripe-userhelp-content/issues/new?labels=documentation).
-[/note]
+> [!NOTE]
+> Sections of User Help are still a work in progress. If you would like to help contribute to the Silverstripe CMS User Help guide you can edit the pages on [GitHub](https://github.com/silverstripe/silverstripe-userhelp-content/) or create an [issue](https://github.com/silverstripe/silverstripe-userhelp-content/issues/new?labels=documentation).
 
 ## Managing your website
 [CHILDREN Folder=01_Managing_your_website]


### PR DESCRIPTION
## IMPORTANT

This should not be merged until all of the associated PRs have all been approved. Only merge when all of the PRs are ready to go, to minimise the amount of time spent with broken callout blocks.

## Description
Converts all of the legacy callout blocks to the new syntax. Note that we're not doing CMS 3. There will also not be a separate CMS 5 PR for this repo - the merge up should be pretty clean.

The target branch was chosen based on the list in https://github.com/silverstripe/doc.silverstripe.org/blob/master/sources-user.js

Note that the callout blocks will be converted as per https://github.com/silverstripe/doc.silverstripe.org/issues/282#issuecomment-1915939874.

## Issues
- https://github.com/silverstripe/doc.silverstripe.org/issues/282